### PR TITLE
Make go-cmb only read `go` section of buildpack.yml

### DIFF
--- a/cmd/detect/main.go
+++ b/cmd/detect/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -37,7 +39,7 @@ func runDetect(context detect.Detect) (int, error) {
 
 	version := context.BuildPlan[golang.Dependency].Version
 	if exists {
-		version, err = helper.ReadBuildpackYamlVersion(buildpackYAMLPath, golang.Dependency)
+		version, err = readBuildpackYamlVersion(buildpackYAMLPath)
 		if err != nil {
 			return detect.FailStatusCode, err
 		}
@@ -48,4 +50,25 @@ func runDetect(context detect.Detect) (int, error) {
 			Version:  version,
 			Metadata: buildplan.Metadata{"build": true, "launch": false},
 		}})
+}
+
+type BuildpackYaml struct {
+	Go struct {
+		Version string `yaml:"version"`
+	} `yaml:"go"`
+}
+
+
+func readBuildpackYamlVersion(buildpackYAMLPath string) (string, error) {
+	buf, err := ioutil.ReadFile(buildpackYAMLPath)
+	if err != nil {
+		return "", err
+	}
+
+	config := BuildpackYaml{}
+	if err := yaml.Unmarshal(buf, &config); err != nil {
+		return "", err
+	}
+
+	return config.Go.Version, nil
 }


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Change the build pack to only read the section of the buildpack relevant to `go`

* An explanation of the use cases your change solves

The details are in https://github.com/cloudfoundry/go-cnb/issues/4

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have added an integration test
There are no integration tests
